### PR TITLE
Prefixed ${NOT_COVERED_SRC} with ${PROJECT_ROOT}.

### DIFF
--- a/cmake/CoverallsGenerateGcov.cmake
+++ b/cmake/CoverallsGenerateGcov.cmake
@@ -389,7 +389,7 @@ endforeach()
 foreach(NOT_COVERED_SRC ${COVERAGE_SRCS_REMAINING})
 
 	# Loads the source file as a list of lines.
-	file(STRINGS ${NOT_COVERED_SRC} SRC_LINES)
+	file(STRINGS ${PROJECT_ROOT}/${NOT_COVERED_SRC} SRC_LINES)
 
 	set(GCOV_FILE_COVERAGE "[")
 	set(GCOV_FILE_SOURCE "")


### PR DESCRIPTION
I believe this should fix the issue I opened (see JoakimSoderberg/coveralls-cmake#2 )
